### PR TITLE
fix(feedback): correct redirect URL after feedback submission (404 error)

### DIFF
--- a/app/(app)/feedback/submit/page.tsx
+++ b/app/(app)/feedback/submit/page.tsx
@@ -41,7 +41,7 @@ export default function FeedbackSubmitPage() {
 
             show({ title: "Feedback submitted", description: "Thanks for your input!" })
             // navigate after a short delay so user sees toast
-            setTimeout(() => router.push("/app/feedback/my-feedback"), 700)
+            setTimeout(() => router.push("/feedback/my-feedback"), 700)
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err)
             show({ title: "Error", description: message })


### PR DESCRIPTION
Fixes #20

#### Problem
After submitting feedback, users were redirected to `/app/feedback/my-feedback` which resulted in a 404 error.

#### Solution
Updated the redirect path in `app/(app)/feedback/submit/page.tsx` to correctly redirect to `/feedback/my-feedback`

Changes Made
- Before: `/app/feedback/my-feedback` (404 error)
- After: `/feedback/my-feedback` (correct)

Files Changed
`app/(app)/feedback/submit/page.tsx`
